### PR TITLE
Code would not compile against the latest version of go-concourse.

### DIFF
--- a/main.go
+++ b/main.go
@@ -35,6 +35,7 @@ func main() {
 func NewClient(url, bearerToken string, ignoreTls bool) concourse.Client {
 	// Initialise the default client before modifying its Transport in place
 	// Panic occurs if this isn't done
+	var tracing = false
 	_, _ = http.DefaultClient.Get("http://127.0.0.1")
 
 	tr := http.DefaultTransport.(*http.Transport)
@@ -52,7 +53,7 @@ func NewClient(url, bearerToken string, ignoreTls bool) concourse.Client {
 
 	httpClient := &http.Client{Transport: transport}
 
-	return concourse.NewClient(url, httpClient)
+	return concourse.NewClient(url, httpClient, tracing)
 }
 
 func GetResourceVersions(client concourse.Client, teamName, pipelineName, jobName, buildName string) (map[string]atc.Version, error) {

--- a/stopover_test.go
+++ b/stopover_test.go
@@ -48,7 +48,7 @@ var _ = Describe("Stopover", func() {
 			bytes, err := ioutil.ReadFile(simulation_path)
 			Ω(err).ShouldNot(HaveOccurred())
 
-			simulation := v2.SimulationViewV3{}
+			simulation := v2.SimulationViewV4{}
 			err = json.Unmarshal(bytes, &simulation)
 			Ω(err).ShouldNot(HaveOccurred())
 


### PR DESCRIPTION
Good afternoon,
We pulled this code and found a couple of minor issues getting it working with the latest versions of its dependencies:

- A new variable was required for the NewClient command, this a boolean for tracing
- The tests did not run due to a change from SimulationViewV3 to SimulationViewV4 in hoverfly
